### PR TITLE
Add support for adding an active class to the slider handle(s)

### DIFF
--- a/example/scss/example.scss
+++ b/example/scss/example.scss
@@ -1,4 +1,4 @@
-@import 'react-input-range';
+@import '@appearhere/react-input-range';
 
 .form {
   height: 200px;

--- a/scss/_InputRangeSlider.scss
+++ b/scss/_InputRangeSlider.scss
@@ -14,10 +14,6 @@
   transition: $InputRange-slider-transition;
   width: $InputRange-slider-width;
 
-  &:active {
-    transform: $InputRange-slider--active-transform;
-  }
-
   &:focus {
     box-shadow: 0 0 0 5px transparentize($InputRange-slider-background, 0.8);
   }
@@ -32,4 +28,8 @@
 
 .InputRange-sliderContainer {
   transition: $InputRange-sliderContainer-transition;
+}
+
+.InputRange-slider--active {
+  transform: $InputRange-slider--active-transform;
 }

--- a/src/InputRange/Slider.js
+++ b/src/InputRange/Slider.js
@@ -43,6 +43,10 @@ export default class Slider extends React.Component {
       'handleTouchMove',
       'handleKeyDown',
     ], this);
+
+    this.state = {
+      active: false,
+    };
   }
 
   /**
@@ -61,6 +65,7 @@ export default class Slider extends React.Component {
     // Event
     document.addEventListener('mousemove', this.handleMouseMove);
     document.addEventListener('mouseup', this.handleMouseUp);
+    this.setState({ active: true });
   }
 
   /**
@@ -71,6 +76,7 @@ export default class Slider extends React.Component {
     // Event
     document.removeEventListener('mousemove', this.handleMouseMove);
     document.removeEventListener('mouseup', this.handleMouseUp);
+    this.setState({ active: false });
   }
 
   /**
@@ -90,6 +96,7 @@ export default class Slider extends React.Component {
 
     document.addEventListener('touchmove', this.handleTouchMove);
     document.addEventListener('touchend', this.handleTouchEnd);
+    this.setState({ active: true });
   }
 
   /**
@@ -109,6 +116,7 @@ export default class Slider extends React.Component {
 
     document.removeEventListener('touchmove', this.handleTouchMove);
     document.removeEventListener('touchend', this.handleTouchEnd);
+    this.setState({ active: false });
   }
 
   /**
@@ -125,7 +133,13 @@ export default class Slider extends React.Component {
    */
   render() {
     const { classNames, Label, children } = this.props;
+    const { active } = this.state;
     const style = getStyle(this);
+
+    const anchorClassName = [
+      classNames.slider,
+      active ? classNames.sliderActive : null,
+    ].join(' ');
 
     return (
       <span
@@ -145,7 +159,7 @@ export default class Slider extends React.Component {
           aria-valuemax={ this.props.maxValue }
           aria-valuemin={ this.props.minValue }
           aria-valuenow={ this.props.formatLabel ? this.props.formatLabel( this.props.value ) : this.props.value }
-          className={ classNames.slider }
+          className={ anchorClassName }
           draggable="false"
           href="#"
           onClick={ this.handleClick }

--- a/src/InputRange/defaultClassNames.js
+++ b/src/InputRange/defaultClassNames.js
@@ -22,6 +22,7 @@ export default {
   labelMin: 'InputRange-label InputRange-label--min',
   labelValue: 'InputRange-label InputRange-label--value',
   slider: 'InputRange-slider',
+  sliderActive: 'InputRange-slider--active',
   sliderContainer: 'InputRange-sliderContainer',
   trackActive: 'InputRange-track InputRange-track--active',
   trackContainer: 'InputRange-track InputRange-track--container',

--- a/test/InputRange.spec.js
+++ b/test/InputRange.spec.js
@@ -33,6 +33,7 @@ describe('InputRange', () => {
         labelMin: 'InputRange-label InputRange-label--min',
         labelValue: 'InputRange-label InputRange-label--value',
         slider: 'InputRange-slider',
+        sliderActive: 'InputRange-slider--active',
         sliderContainer: 'InputRange-sliderContainer',
         trackActive: 'InputRange-track InputRange-track--active',
         trackContainer: 'InputRange-track InputRange-track--container',


### PR DESCRIPTION
Touch/drag input doesn't work with the `:active` pseudo selector. This allows us to style the `:active` state directly with a className by manually managing this state